### PR TITLE
Adds MIT License file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016-present, Przeysław (Przemek) Kusiak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Hi Przemek,

I am the developer of "Rescuezilla", an easy-to-use graphical drop-in replacement to Clonezilla licensed under GPLv3. I am currently implementing Rescuezilla's [Image Explorer](https://github.com/rescuezilla/rescuezilla/issues/20) functionality.

While researching methods to mount and explore partclone images I have come across your work. There are a number of independent forks of a similar application named [partclone-utils](https://sourceforge.net/p/partclone-utils) (licensed under GPLv2), which I am trying my best to painstakingly unify.

**Is partclone-nbd still licensed under the MIT License? If so, please consider accepting the Pull Request below.**

Side note: Since you are currently the sole author of this application, you can switch the license at any time (with all the existing code of course continuing to be licensed under the existing arrangements).