### PR TITLE
Flush stdout/stderr streams for line-by-line processing by external apps, adds -Wall, Werror compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,5 +22,7 @@ target_link_libraries(
     ${PROJECT_NAME} pthread
 )
 
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror)
+
 ## install rules
 install (TARGETS partclone-nbd DESTINATION bin)

--- a/include/image.h
+++ b/include/image.h
@@ -53,7 +53,7 @@ struct image
     u32 o_remaining_bytes;
     // is this block present in the image or does it remain unused?
     u8  o_existence;
-    // no. of set blocks from the beggining of the image to this block
+    // no. of set blocks from the beginning of the image to this block
     u64 o_blocks_set;
     // the pointer to the last element of the bitmap
     u64 *o_bitmap_ptr;
@@ -102,9 +102,9 @@ struct image
 	u16 checksum_size;
 	// how many blocks are checksumed together
 	u32 blocks_per_checksum;
-    // offset of data (from the beggining of the image)
+    // offset of data (from the beginning of the image)
     u64 data_offset;
-    // offset of on-disk bitmap (from the beggining of the image)
+    // offset of on-disk bitmap (from the beginning of the image)
     u64 bitmap_offset;
 };
 

--- a/include/io.h
+++ b/include/io.h
@@ -39,7 +39,7 @@ static inline status read_whole(int fd, void *dest, size_t size)
     {
         if(once_read > 0)
         {
-            dest   +=  once_read;
+            dest   =  (u8*)dest + once_read;
             size   -=  (size_t) once_read;
         }
         else if(errno != EINTR)

--- a/src/image.c
+++ b/src/image.c
@@ -106,7 +106,7 @@ status load_image(struct image *img, struct options *options)
         log_error("Cannot read image header: %s.", strerror(errno));
         goto error_2;
     } else {
-        log_debug("Image header readed.");
+        log_debug("Image header read.");
     }
 
     if(memcmp(head.v1.magic, "partclone-image", 15) != 0) {

--- a/src/log.c
+++ b/src/log.c
@@ -129,6 +129,7 @@ NOT_LITERAL void log_msg(enum log_priority priority, const char *format, ...)
     fprintf(stream, "%s", print_priority_string[priority]);
     vfprintf(stream, format, args);
     fprintf(stream, "\n");
+    fflush(stream);
 
     va_end(args);
 }

--- a/src/log.c
+++ b/src/log.c
@@ -102,7 +102,7 @@ NOT_LITERAL void log_msg(enum log_priority priority, const char *format, ...)
     
     if(quiet) return;
 
-    FILE *stream;
+    FILE *stream = NULL;
 
     switch(priority)
     {
@@ -114,6 +114,8 @@ NOT_LITERAL void log_msg(enum log_priority priority, const char *format, ...)
     case log_debug:
         if(!debug)
             return;
+        stream = stdout;
+        break;
 
     // to stdout
     case log_info:

--- a/src/main.c
+++ b/src/main.c
@@ -123,6 +123,7 @@ int main(int argc, char **argv)
 
         case 'D':
             options.debug = 1;
+            break;
 
         case 'c':
             if(options.server_mode) {

--- a/src/nbd.c
+++ b/src/nbd.c
@@ -75,7 +75,7 @@ int get(int sock, void *buff, int count)
 
         pnt += once;
         cnt -= once;
-        buff += once;
+        buff = (u8*) buff + once;
     }
 
     return pnt;
@@ -97,7 +97,7 @@ ssize_t put(int sock, void *buff, size_t count)
 
         pnt += once;
         cnt -= once;
-        buff += once;
+        buff = (u8*) buff + once;
     }
 
     if(pnt != count) log_error("Failed to send data to an image.");
@@ -316,7 +316,8 @@ status start_server(struct image *img, struct options *options)
     struct sockaddr_in server_addr = {
         .sin_family = AF_INET,
         .sin_addr.s_addr = htonl(INADDR_ANY),
-        .sin_port = htons(options->port)
+        .sin_port = htons(options->port),
+        .sin_zero = { 0 }
     };
 
     if(bind(sock, (struct sockaddr*) &server_addr, sizeof server_addr) == -1) {


### PR DESCRIPTION
Hi again Przemek,

As mentioned in #2, I am the developer of "Rescuezilla", an easy-to-use graphical drop-in replacement to Clonezilla licensed under GPLv3. I am currently implementing Rescuezilla's [Image Explorer](https://github.com/rescuezilla/rescuezilla/issues/20) functionality.

To make sure my minor work so far on partclone-nbd doesn't become like partclone-utils (lots of [independent forks](https://sourceforge.net/p/partclone-utils/git/merge-requests/6/)) I am creating this pull request with my minor improvements so far.

**Random notes:**

I like partclone-nbd. It's lightweight and pretty well-written. I like that CMake makes out-of-tree builds trivial compared to partclone-utils' autoconf.

partclone-nbd definitely handles NTFS filesystems better than the current partclone-utils forks, so Rescuezilla v2.1 will use partclone-nbd. However I adapted a partclone-utils test script and found that partclone-nbd does appear to have issues around some filesystem types. partclone-utils happens to also support "ntfsclone" which is used by Clonezilla and so is of great interest to Rescuezilla. **Because of partclone-utils' ntfsclone support, I hope to do the bulk of my future Image Explorer-related development on the partclone-utils rather than partclone-nbd.**